### PR TITLE
gen-versionh.sh: make it work with sources from a git-archive

### DIFF
--- a/scripts/gen-versionh.sh
+++ b/scripts/gen-versionh.sh
@@ -32,14 +32,14 @@ makefilever()
 
 GIT=`which git 2>/dev/null`
 if [ "$DEVEL" == "1" ]; then
-  if [ ! -f ${GIT} ]; then
-    makefilever
-  else
+  if [ ! -z ${GIT} -a -f ${GIT} -a -d ${0%/*}/../.git ]; then
     VER=$(${GIT} describe --always)
     if [ "$OLD" != "$VER" ]; then
       hdr
       echo "#define VERSION \""$VER\" >> $HEADER
     fi
+  else
+    makefilever
   fi
 else
   makefilever


### PR DESCRIPTION
Hi,

This short series does some cleanup of the bash gen-versionh.sh script and fix it to work properly when the source tarball has been generated with git-archive.

Regards,

Samuel
