### PR TITLE
Add /dev/kmem to the list of dangerous devices that Trinity should not access.

### DIFF
--- a/fds/files.c
+++ b/fds/files.c
@@ -47,7 +47,7 @@ static int ignore_files(const char *path)
 		"/proc/sysrq-trigger", "/proc/kmem", "/proc/kcore",
 
 		/* dangerous/noisy/annoying stuff in /dev */
-		"/dev/log", "/dev/mem", "/dev/kmsg",
+		"/dev/log", "/dev/mem", "/dev/kmsg", "/dev/kmem",
 		NULL
 	};
 


### PR DESCRIPTION
Writing to it may cause kernel memory corruption.