### PR TITLE
linux/nvme.h has been renamed in linux 4.4 to linux/nvme_ioctl.h

### DIFF
--- a/configure
+++ b/configure
@@ -204,7 +204,7 @@ rm -f "$TMP" || exit 1
 
 cat >"$TMP.c" << EOF
 #include <sys/ioctl.h>
-#include <linux/nvme.h>
+#include <linux/nvme_ioctl.h>
 
 int main(int argc, char* argv[])
 {

--- a/ioctls/nvme.c
+++ b/ioctls/nvme.c
@@ -1,7 +1,7 @@
 #include "config.h"
 #ifdef USE_NVME
 #include <linux/ioctl.h>
-#include <linux/nvme.h>
+#include <linux/nvme_ioctl.h>
 
 #include "compat.h"
 #include "utils.h"


### PR DESCRIPTION
point to new header file names