### PR TITLE
Fix issue preventing compilation against glibc for linux < 4.5

### DIFF
--- a/include/compat.h
+++ b/include/compat.h
@@ -669,7 +669,9 @@ enum kcmp_type {
 #define IPV6_RECVFRAGSIZE       77
 #endif
 
-
+#ifndef IPV6_HDRINCL
+#define IPV6_HDRINCL		36
+#endif
 
 /* asm/resource.h */
 #ifndef RLIMIT_RTTIME


### PR DESCRIPTION
Glibc for older kernels ( < 4.5 ) do not have the definition of IPV6_HDRINCL. In particular, this prevents Trinity being built for Ubuntu 16.04.1 LTS.