### PR TITLE
Fix --enable-fds bash list expansion bug

### DIFF
--- a/fds/fds.c
+++ b/fds/fds.c
@@ -20,6 +20,7 @@ static unsigned int num_fd_providers;			// num in list.
 static unsigned int num_fd_providers_to_enable = 0;	// num of --fd-enable= params
 static unsigned int num_fd_providers_enabled = 0;	// final num we enabled.
 static unsigned int num_fd_providers_initialized = 0;	// num we called ->init on
+static bool enable_fd_initialized = FALSE;		// initialized (disabled all) fd providers
 
 static struct fd_provider *fd_providers = NULL;
 
@@ -194,7 +195,7 @@ void process_fds_param(char *param, bool enable)
 
 	len = strlen(param);
 
-	if (enable == TRUE) {
+	if (enable_fd_initialized == FALSE && enable == TRUE) {
 		struct list_head *node;
 
 		/* First, pass through and mark everything disabled. */
@@ -204,6 +205,7 @@ void process_fds_param(char *param, bool enable)
 			provider = (struct fd_provider *) node;
 			provider->enabled = FALSE;
 		}
+		enable_fd_initialized = TRUE;
 	}
 
 	/* Check if there are any commas. If so, split them into multiple params,


### PR DESCRIPTION
This fixes a bug in the handling of bash expanded string lists as an argument in --enable-fds. When called in the recommended way, for each argument passed in --enable-fds{a,b,c} the list of enabled fds is wiped in process_fds_param, but the total count is not decremented, making the later fd procider initialization hang. This fix ensures that the list is only wiped the first time an --enable-fds argument is processed by setting a global enable_fd_initialized flag.