### PR TITLE
Fix a rare double reap bug

### DIFF
--- a/main.c
+++ b/main.c
@@ -87,6 +87,9 @@ static int shm_is_corrupt(void)
  */
 void reap_child(struct childdata *child)
 {
+	/* Don't reap a child again */
+	if( pids[child->num] == EMPTY_PIDSLOT )
+		return;
 	child->tp = (struct timespec){ .tv_sec = 0, .tv_nsec = 0 };
 	unlock(&child->syscall.lock);
 	shm->running_childs--;


### PR DESCRIPTION
Occasionally the parent can reach a situation where it attempts to reap a child via handle_child which has previously already been reaped by reap_dead_kids. This check simply ensures that the child's pid is not empty before continuing.