### PR TITLE
Fix compilation issue in  output.c

### DIFF
--- a/output.c
+++ b/output.c
@@ -30,7 +30,7 @@ void output(char level, const char *fmt, ...)
 	if (level >= quiet_level)
 		return;
 
-	if (level == CONT) {
+	if (level == (char)CONT) {
 		prefix = continuationtxt;
 		goto skip_pid;
 	}


### PR DESCRIPTION
compilation failed with 
output.c:33:12: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  if (level == CONT) {
            ^~
cc1: all warnings being treated as errors
Makefile:126: recipe for target 'output.o' failed

fixed type cast CONT with char

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>