### PR TITLE
Fix compilation issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ CFLAGS += -Wundef
 CFLAGS += -Wwrite-strings
 CFLAGS += -Wno-format-nonliteral
 CFLAGS += -Wstrict-prototypes -Wmissing-prototypes
+CFLAGS += -fsigned-char
 
 # needed for show_backtrace() to work correctly.
 LDFLAGS += -rdynamic


### PR DESCRIPTION
compilation failed with
output.c:33:12: error: comparison is always false due to limited range of data type [-Werror=type-limits]
if (level == CONT) {
^~
cc1: all warnings being treated as errors
Makefile:126: recipe for target 'output.o' failed

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>