### PR TITLE
fix memory corruption in tables-uniarch:log_enabled_syscalls_uniarch

### DIFF
--- a/tables-uniarch.c
+++ b/tables-uniarch.c
@@ -185,7 +185,7 @@ void log_enabled_syscalls_uniarch(void)
 	unsigned int i, index = 0;
 	unsigned int size;
 
-	size = sizeof(struct msg_syscallsenabled) + shm->nr_active_syscalls;
+	size = sizeof(struct msg_syscallsenabled) + (sizeof(int) * shm->nr_active_syscalls);
 	udpmsg = zmalloc(size);
 	init_msghdr(&udpmsg->hdr, SYSCALLS_ENABLED);
 	udpmsg->nr_enabled = shm->nr_active_syscalls;


### PR DESCRIPTION
facing  memory corruption while running trinity bin as it size for doing zmalloc having issue 

Log:
inux-4aba:~/testst/trinity # ./trinity 
Trinity v1.7-190-gd14f212a  Dave Jones <davej@codemonkey.org.uk>
shm:0x3fff8d330000-0x3fffc02acd08 (1 pages)
[main] Done parsing arguments.
[main] shm is at 0x3fff8d330000
[main] Initial random seed: 3892824537
[main] Kernel was tainted on startup. Will ignore flags that are already set.
Marking all syscalls as enabled.
[main] Enabled 358 syscalls. Disabled 0 syscalls.
*** Error in `./trinity': free(): invalid next size (normal): 0x00000100070b0530 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x84d4c)[0x3fff8d1b4d4c]
/lib64/libc.so.6(+0x8d724)[0x3fff8d1bd724]
/lib64/libc.so.6(+0x8e7b0)[0x3fff8d1be7b0]
./trinity(log_enabled_syscalls_uniarch+0x128)[0x10019758]
./trinity(log_enabled_syscalls+0x3c)[0x1001ad9c]
./trinity(munge_tables+0x198)[0x1001af78]
./trinity(main+0x154)[0x1000ce64]

solution :

size change to (sizeof(int) * shm->nr_active_syscalls

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>