### PR TITLE
memfd: fix build with glibc 2.27

### DIFF
--- a/configure
+++ b/configure
@@ -289,6 +289,29 @@ else
 fi
 
 #############################################################################################
+# Does glibc provide memfd_create() syscall wrapper
+#
+echo -n "[*] Checking if glibc provides memfd_create.. "
+rm -f "$TMP" || exit 1
+
+cat >"$TMP.c" << EOF
+#include <sys/mman.h>
+
+void main()
+{
+	memfd_create();
+}
+EOF
+
+${CC} ${CFLAGS} "$TMP.c" -o "$TMP" &>"$TMP.log"
+if [ ! -x "$TMP" ]; then
+	echo $RED "[NO]" $COL_RESET
+else
+	echo $GREEN "[YES]" $COL_RESET
+	echo "#define USE_MEMFD_CREATE 1" >> $CONFIGH
+fi
+
+#############################################################################################
 
 check_header linux/caif/caif_socket.h USE_CAIF
 check_header linux/fsmap.h USE_FSMAP

--- a/fds/memfd.c
+++ b/fds/memfd.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/mman.h>
 
 #include "fd.h"
 #include "memfd.h"
@@ -16,6 +17,7 @@
 #include "trinity.h"
 #include "udp.h"
 
+#ifndef USE_MEMFD_CREATE
 static int memfd_create(__unused__ const char *uname, __unused__ unsigned int flag)
 {
 #ifdef SYS_memfd_create
@@ -24,6 +26,7 @@ static int memfd_create(__unused__ const char *uname, __unused__ unsigned int fl
 	return -ENOSYS;
 #endif
 }
+#endif
 
 static void memfd_destructor(struct object *obj)
 {


### PR DESCRIPTION
glibc 2.27 added a wrapper for memfd_create(). This causes build
failure:

fds/memfd.c:19:12: error: static declaration of 'memfd_create' follows non-static declaration
 static int memfd_create(__unused__ const char *uname, __unused__ unsigned int flag)
            ^~~~~~~~~~~~

Don't use the local definition when the libc provides one.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>