### PR TITLE
Fix pthread undefined references

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -29,7 +29,7 @@ endif
 # Sometimes useful for debugging. more useful with clang than gcc.
 #CFLAGS += -fsanitize=address
 
-LDFLAGS = -lpthread
+LDFLAGS = -pthread
 
 V	= @
 Q	= $(V:1=)


### PR DESCRIPTION
On Ubuntu 18.04, trinity 1.8 fails to build with undefined references. This patch fixes that.

Full build log
----------------
https://launchpad.net/ubuntu/+source/trinity/1.8-3/+build/14520211

Build log excerpt
---------------------
```
make[2]: Entering directory '/<<PKGBUILDDIR>>/server'
  CC	child.o
  CC	decode.o
  CC	logfiles.o
  CC	main.o
  CC	objects.o
  CC	syscalls.o
  CC	trinityserver.o
  CC	udp-server.o
  CC	utils.o
  CC	trinityserver
trinityserver.o: In function `decoder_main_func':
./server/trinityserver.c:126: undefined reference to `pthread_yield'
trinityserver.o: In function `decoder_func':
./server/trinityserver.c:92: undefined reference to `pthread_mutex_trylock'
./server/trinityserver.c:97: undefined reference to `pthread_yield'
trinityserver.o: In function `__handshake':
./server/trinityserver.c:167: undefined reference to `pthread_create'
trinityserver.o: In function `main':
./server/trinityserver.c:393: undefined reference to `pthread_create'
./server/trinityserver.c:399: undefined reference to `pthread_join'
./server/trinityserver.c:397: undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
```