### PR TITLE
configure: fix build with kernel headers v4.17+

### DIFF
--- a/configure
+++ b/configure
@@ -316,6 +316,7 @@ fi
 check_header linux/caif/caif_socket.h USE_CAIF
 check_header linux/fsmap.h USE_FSMAP
 check_header linux/if_alg.h USE_IF_ALG
+check_header linux/irda.h USE_IRDA
 check_header linux/rds.h USE_RDS
 check_header linux/vfio.h USE_VFIO
 check_header drm/drm.h USE_DRM

--- a/net/proto-irda.c
+++ b/net/proto-irda.c
@@ -4,12 +4,14 @@
 #include <sys/un.h>
 /* old irda.h does not include something which defines sa_family_t */
 #include <netinet/in.h>
-#include <linux/irda.h>
 #include <stdlib.h>
 #include "net.h"
 #include "random.h"
 #include "utils.h"	// RAND_ARRAY
 #include "compat.h"
+
+#ifdef USE_IRDA
+#include <linux/irda.h>
 
 static void irda_gen_sockaddr(struct sockaddr **addr, socklen_t *addrlen)
 {
@@ -53,3 +55,5 @@ const struct netproto proto_irda = {
 	.valid_triplets = irda_triplets,
 	.nr_triplets = ARRAY_SIZE(irda_triplets),
 };
+
+#endif

--- a/net/protocols.c
+++ b/net/protocols.c
@@ -26,7 +26,9 @@ const struct protoptr net_protocols[TRINITY_PF_MAX] = {
 #ifdef USE_RDS
 	[PF_RDS] = { .proto = &proto_rds },
 #endif
+#ifdef USE_IRDA
 	[PF_IRDA] = { .proto = &proto_irda },
+#endif
 	[PF_LLC] = { .proto = &proto_llc },
 	[PF_CAN] = { .proto = &proto_can },
 	[PF_TIPC] = { .proto = &proto_tipc },


### PR DESCRIPTION
Kernel v4.17 removed the linux/irda.h header. Skip the irda test when
this header is missing.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>