### PR TITLE
trinity: check pidstatfile before fclose

### DIFF
--- a/main.c
+++ b/main.c
@@ -566,8 +566,8 @@ static void handle_childsig(int childno, int childstatus, bool stop)
 			log_child_signalled(childno, pid, WTERMSIG(childstatus), child->op_nr);
 		}
 		reap_child(shm->children[childno]);
-
-		fclose(child->pidstatfile);
+		if (child->pidstatfile)
+			fclose(child->pidstatfile);
 		child->pidstatfile = NULL;
 
 		replace_child(childno);


### PR DESCRIPTION
Below run got segment fault. This is caused by fclose to a null
pidstatfile. Fix by checking it before executing fclose on it.

	trinity -csplice,move_pages -q -N 20

Signed-off-by: Chunyu Hu <chuhu@redhat.com>