### PR TITLE
Fixed trinity compile issue as on gcc :gcc (Ubuntu 8.2.0-6ubuntu1) 8.2.0

### DIFF
--- a/syscalls/perf_event_open.c
+++ b/syscalls/perf_event_open.c
@@ -278,10 +278,10 @@ static int init_pmus(void) {
 	DIR *dir,*event_dir,*format_dir;
 	struct dirent *entry,*event_entry,*format_entry;
 	char dir_name[BUFSIZ] = "";
-	char event_name[BUFSIZ] = "";
+	char event_name[BUFSIZ+7] = "";
 	char event_value[BUFSIZ] = "";
-	char temp_name[BUFSIZ] = "";
-	char format_name[BUFSIZ] = "";
+	char temp_name[BUFSIZ*2] = "";
+	char format_name[BUFSIZ+7] = "";
 	char format_value[BUFSIZ] = "";
 	int type,pmu_num=0,format_num=0,generic_num=0;
 	FILE *fff;


### PR DESCRIPTION
it failed as -Werror=format-overflow=
while assigning a array variable as size over flow

this patch address that issue to increase array size how much it require

LOG:
syscalls/perf_event_open.c: In function ‘init_pmus’:
syscalls/perf_event_open.c:332:24: error: ‘/type’ directive writing 5 bytes into a region of size between 1 and 8192 [-Werror=format-overflow=]
   sprintf(temp_name,"%s/type",dir_name);
                        ^~~~~
In file included from /usr/include/stdio.h:873,
                 from include/list.h:3,
                 from include/maps.h:5,
                 from syscalls/perf_event_open.c:13:
/usr/include/powerpc64le-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 6 and 8197 bytes into a destination of size 8192
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
syscalls/perf_event_open.c:345:26: error: ‘/format’ directive writing 7 bytes into a region of size between 1 and 8192 [-Werror=format-overflow=]
   sprintf(format_name,"%s/format",dir_name);
                          ^~~~~~~
In file included from /usr/include/stdio.h:873,
                 from include/list.h:3,
                 from include/maps.h:5,
                 from syscalls/perf_event_open.c:13:
/usr/include/powerpc64le-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 8 and 8199 bytes into a destination of size 8192
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
syscalls/perf_event_open.c:382:26: error: ‘/format/’ directive writing 8 bytes into a region of size between 1 and 8192 [-Werror=format-overflow=]
     sprintf(temp_name,"%s/format/%s",
                          ^~~~~~~~
In file included from /usr/include/stdio.h:873,
                 from include/list.h:3,
                 from include/maps.h:5,
                 from syscalls/perf_event_open.c:13:
/usr/include/powerpc64le-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 9 and 8455 bytes into a destination of size 8192
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
syscalls/perf_event_open.c:405:25: error: ‘/events’ directive writing 7 bytes into a region of size between 1 and 8192 [-Werror=format-overflow=]
   sprintf(event_name,"%s/events",dir_name);
                         ^~~~~~~
In file included from /usr/include/stdio.h:873,
                 from include/list.h:3,
                 from include/maps.h:5,
                 from syscalls/perf_event_open.c:13:
/usr/include/powerpc64le-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 8 and 8199 bytes into a destination of size 8192
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
syscalls/perf_event_open.c:443:26: error: ‘/events/’ directive writing 8 bytes into a region of size between 1 and 8192 [-Werror=format-overflow=]
     sprintf(temp_name,"%s/events/%s",
                          ^~~~~~~~
In file included from /usr/include/stdio.h:873,
                 from include/list.h:3,
                 from include/maps.h:5,
                 from syscalls/perf_event_open.c:13:
/usr/include/powerpc64le-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 9 and 8455 bytes into a destination of size 8192
   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       __bos (__s), __fmt, __va_arg_pack ());
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:131: syscalls/perf_event_open.o] Error 1

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>