### PR TITLE
trinity: define TRINITY_PF_MAX as 45

### DIFF
--- a/include/net.h
+++ b/include/net.h
@@ -15,7 +15,7 @@ extern unsigned int specific_domain;
 
 /* glibc headers might be older than the kernel, so chances are we know
  * about more protocols than glibc does. So we define our own PF_MAX */
-#define TRINITY_PF_MAX 44
+#define TRINITY_PF_MAX 45
 
 #define PF_NOHINT (-1)
 


### PR DESCRIPTION
The PF_MAX is defined as 45 in mainline kernel, while TRINITY_PF_MAX is 44
currently, so a segment fault was hit in do_random_sso(), where PF_MAX is
used to generate the net_protocols[] index, can be 44 at most, out of the
bounder of the array.

Signed-off-by: Chunyu Hu <chuhu@redhat.com>