### PR TITLE
Fix build with GCC 10.

### DIFF
--- a/include/logfile.h
+++ b/include/logfile.h
@@ -5,7 +5,7 @@
 FILE *find_logfile_handle(void);
 void synclogs(void);
 
-FILE *mainlogfile;
+extern FILE *mainlogfile;
 void open_main_logfile(void);
 void close_logfile(FILE **handle);
 


### PR DESCRIPTION
  CC	trinity
/usr/bin/ld: debug.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
/usr/bin/ld: log-files.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
/usr/bin/ld: log.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
/usr/bin/ld: main.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
/usr/bin/ld: output.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
/usr/bin/ld: params.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
/usr/bin/ld: shm.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here
/usr/bin/ld: trinity.o:include/logfile.h:8: multiple definition of `mainlogfile'; child.o:include/logfile.h:8: first defined here

Fixes: 13856316c259 ("reinstate the log-to-file code for now.")
Signed-off-by: Vinson Lee <vlee@freedesktop.org>