### PR TITLE
fix: previous_op_count may more than op_count case process data compete

### DIFF
--- a/main.c
+++ b/main.c
@@ -37,7 +37,11 @@ static int shm_is_corrupt(void)
 {
 	unsigned int i;
 
-	if (shm->stats.op_count < shm->stats.previous_op_count) {
+	unsigned long current_previous_op_count = shm->stats.previous_op_count;
+	unsigned long current_op_count = shm->stats.op_count;
+
+	//if (shm->stats.op_count < shm->stats.previous_op_count) {
+	if (current_op_count < current_previous_op_count) {
 		output(0, "Execcount went backwards! (old:%ld new:%ld):\n",
 			shm->stats.previous_op_count, shm->stats.op_count);
 		panic(EXIT_SHM_CORRUPTION);

--- a/shm.c
+++ b/shm.c
@@ -49,6 +49,7 @@ void init_shm(void)
 		shm->debug = TRUE;
 
 	shm->stats.op_count = 0;
+	shm->stats.previous_op_count = 0;
 
 	shm->seed = init_seed(seed);
 


### PR DESCRIPTION
 I met this under mips64 debian.

cmd: su - trinity -c "/home/trinity/trinity-master/trinity -N 1000000"

uname -a: Linux version 4.19.0-loongson-3-server #1187 SMP PREEMPT Wed Mar 25 22:36:49 CST 2020 mips64 GNU/Linux

Error Log:
[main]  Execcount went backwards! (old:126247 new:126240):
[main]  Bailing main loop because SHM was corrupted!.
[main]  Ran 126242 syscalls. Successes: 26475  Failures: 98421

[trinity.log](https://github.com/kernelslacker/trinity/files/4569827/trinity.log)



