### PR TITLE
panic when fd number is close to limition

### DIFF
--- a/include/trinity.h
+++ b/include/trinity.h
@@ -3,6 +3,7 @@
 #include "types.h"
 
 extern unsigned int num_online_cpus;
+extern struct rlimit max_files_rlimit;
 extern bool no_bind_to_cpu;
 
 extern char *progname;

--- a/include/utils.h
+++ b/include/utils.h
@@ -55,6 +55,8 @@ void kill_pid(pid_t pid);
 
 void freeptr(unsigned long *p);
 
+int get_num_fds(void);
+
 #define __stringify_1(x...)     #x
 #define __stringify(x...)       __stringify_1(x)
 

--- a/trinity.c
+++ b/trinity.c
@@ -2,6 +2,7 @@
 #include <malloc.h>
 #include <string.h>
 #include <sys/prctl.h>
+#include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -36,6 +37,7 @@ unsigned int page_size;
 unsigned int num_online_cpus;
 bool no_bind_to_cpu;
 unsigned int max_children;
+struct rlimit max_files_rlimit;
 
 /*
  * just in case we're not using the test.sh harness, we
@@ -106,6 +108,8 @@ int main(int argc, char* argv[])
 	progname = argv[0];
 
 	mainpid = getpid();
+
+    getrlimit(RLIMIT_NOFILE, &max_files_rlimit);
 
 	page_size = getpagesize();
 	num_online_cpus = sysconf(_SC_NPROCESSORS_ONLN);

--- a/utils.c
+++ b/utils.c
@@ -1,9 +1,13 @@
+#include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/types.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include "debug.h"
 #include "pids.h"
 #include "random.h"
@@ -106,4 +110,21 @@ void freeptr(unsigned long *p)
 	if (ptr != NULL)
 		free(ptr);
 	*p = 0L;
+}
+
+int get_num_fds(void)
+{
+     int fd_count;
+     char buf[64];
+     struct dirent *dp;
+
+     snprintf(buf, 64, "/proc/%i/fd/", mainpid);
+
+     fd_count = 0;
+     DIR *dir = opendir(buf);
+     while ((dp = readdir(dir)) != NULL) {
+          fd_count++;
+     }
+     closedir(dir);
+     return fd_count;
 }


### PR DESCRIPTION
Trinity on cpus which have many cores may open large number of
child->pidstatfile, and may be reach the limition(1024 on most
platforms), so just panic and warn user to increase the limition.