### PR TITLE
net/proto-ip-raw.c: fix build with kernel >= 5.13

### DIFF
--- a/net/proto-ip-raw.c
+++ b/net/proto-ip-raw.c
@@ -1,3 +1,4 @@
+#include <netinet/in.h>
 #include <linux/icmp.h>
 #include "net.h"
 #include "trinity.h"


### PR DESCRIPTION
Fix the following build failure with kernel >= 5.13:

```
In file included from /home/buildroot/autobuild/instance-2/output-1/host/powerpc-buildroot-linux-uclibc/sysroot/usr/include/linux/icmp.h:23,
                 from net/proto-ip-raw.c:1:
/home/buildroot/autobuild/instance-2/output-1/host/powerpc-buildroot-linux-uclibc/sysroot/usr/include/netinet/in.h:33:5: error: redeclaration of enumerator 'IPPROTO_IP'
   33 |     IPPROTO_IP = 0,    /* Dummy protocol for TCP.  */
      |     ^~~~~~~~~~
/home/buildroot/autobuild/instance-2/output-1/host/powerpc-buildroot-linux-uclibc/sysroot/usr/include/linux/in.h:29:3: note: previous definition of 'IPPROTO_IP' was here
   29 |   IPPROTO_IP = 0,  /* Dummy protocol for TCP  */
      |   ^~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/c58119baed8d7711da799e34a5ee1117f46b96f4

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>