### PR TITLE
protect other children's shm from corruption

### DIFF
--- a/child.c
+++ b/child.c
@@ -189,6 +189,14 @@ static void init_child(struct childdata *child, int childno)
 {
 	pid_t pid = getpid();
 	char childname[17];
+	unsigned int i;
+
+	for_each_child(i) {
+		if (child->num != i)
+			mprotect(shm->children[i], sizeof(struct childdata), PROT_READ);
+	}
+
+	mprotect(pids, max_children * sizeof(int), PROT_READ);
 
 	/* Wait for parent to set our childno */
 	while (pids[childno] != pid) {


### PR DESCRIPTION
When one child is corrupt,we want to know who is corrupt. But when
it corrupts other one's shm,we can not know who caused the corruption.
So protect other children from corruption.

Signed-off-by: Hongchen Zhang <zhanghongchen@loongson.cn>