### PR TITLE
do not let created timer send SIGINT signal

### DIFF
--- a/syscalls/timer_create.c
+++ b/syscalls/timer_create.c
@@ -3,7 +3,30 @@
 	struct sigevent __user *, timer_event_spec,
 	timer_t __user *, created_timer_id)
  */
+#include <signal.h>
+
 #include "sanitise.h"
+#include "random.h"
+
+static void timer_create_sanitise(struct syscallrecord *rec)
+{
+	struct sigevent *sigev;
+	int signo;
+
+	if (RAND_BOOL()) {
+		sigev = (struct sigevent *) get_writable_address(sizeof(struct sigevent));
+
+		/* do not let created timer send SIGINT signal */
+		do {
+			signo = random() % _NSIG;
+		} while (signo  == SIGINT);
+
+		sigev->sigev_signo = signo;
+	} else
+		sigev = NULL;
+
+	rec->a2 = (unsigned long)sigev;
+}
 
 struct syscallentry syscall_timer_create = {
 	.name = "timer_create",
@@ -13,4 +36,5 @@ struct syscallentry syscall_timer_create = {
 	.arg2type = ARG_ADDRESS,
 	.arg3name = "create_timer_id",
 	.arg3type = ARG_ADDRESS,
+	.sanitise = timer_create_sanitise,
 };


### PR DESCRIPTION
Hello Dave,
When a child process tests timer_create interface with sigev->sigev_signo
equal to SIGINT, and then timer_settime let the timer go.When the timer
has expired, a SIGINT would send to our child process. But SIGINT signal
means ctrl-c is pressed,and then trinity-main will exit.

To Avoid it, do not let timer_create create a timer with
sigev->sigev_signo equal to SIGINT.

Change-Id: I3aa1b99ff447a4a0a8bc2a9d33cf91f7e48cd275
Signed-off-by: Hongchen Zhang <zhanghongchen@loongson.cn>

Best Regards.
Hongchen Zhang