### PR TITLE
Ignore compiler warning

### DIFF
--- a/net/proto-phonet.c
+++ b/net/proto-phonet.c
@@ -9,6 +9,8 @@
 #include "utils.h"
 #include "compat.h"
 
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+
 static void phonet_gen_sockaddr(struct sockaddr **addr, socklen_t *addrlen)
 {
 	struct sockaddr_pn *pn;

--- a/net/proto-pppox.c
+++ b/net/proto-pppox.c
@@ -13,6 +13,8 @@
 #include "utils.h"
 #include "compat.h"
 
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+
 static void pppox_PX_PROTO_OE(struct sockaddr **addr, socklen_t *addrlen)
 {
 	struct sockaddr_pppox *pppox;


### PR DESCRIPTION
Both sockaddr_pn and sockaddr_pppox are defined as "packed"
on x86-64, unlike struct sockaddr, which generates warnings
like this:

net/proto-phonet.c: In function ‘phonet_gen_sockaddr’:
net/proto-phonet.c:22:18: warning: converting a packed ‘struct sockaddr_pn’ pointer (alignment 1) to a ‘struct sockaddr’ pointer (alignment 2) may result in an unaligned pointer value [-Waddress-of-packed-member]
   22 |  *addr = (struct sockaddr *) pn;
      |                  ^~~~~~~~
In file included from net/proto-phonet.c:5:
/usr/include/linux/phonet.h:102:8: note: defined here
  102 | struct sockaddr_pn {
      |        ^~~~~~~~~~~
In file included from /usr/include/x86_64-linux-gnu/sys/socket.h:33,
                 from net/proto-phonet.c:2:
/usr/include/x86_64-linux-gnu/bits/socket.h:178:8: note: defined here
  178 | struct sockaddr
      |        ^~~~~~~~

I'm pretty sure the alignment is fine as other things would
be broken if they weren't, so just ignore the warnings in
these two files.