### PR TITLE
kvm: drop KVM_SET_MEMORY_REGION

### DIFF
--- a/ioctls/kvm.c
+++ b/ioctls/kvm.c
@@ -8,7 +8,6 @@
 #include "utils.h"
 
 static const struct ioctl kvm_ioctls[] = {
-	IOCTL(KVM_SET_MEMORY_REGION),
 	IOCTL(KVM_CREATE_VCPU),
 	IOCTL(KVM_GET_DIRTY_LOG),
 	IOCTL(KVM_SET_NR_MMU_PAGES),


### PR DESCRIPTION
It was dropped in upstream in commit 61e15f871241 (KVM: Delete all references to removed KVM_SET_MEMORY_REGION ioctl).