### PR TITLE
Avoid array access out of bounds error during initialzation of fd pro…

### DIFF
--- a/syscalls/setsockopt.c
+++ b/syscalls/setsockopt.c
@@ -94,7 +94,7 @@ static void do_random_sso(struct sockopt *so, struct socket_triplet *triplet)
 retry:
 	switch (rnd() % 4) {
 	case 0:	/* do a random protocol, even if it doesn't match this socket. */
-		i = rnd() % PF_MAX;
+		i = rnd() % TRINITY_PF_MAX;
 		proto = net_protocols[i].proto;
 		if (proto != NULL) {
 			if (proto->setsockopt != NULL) {


### PR DESCRIPTION
Hello developers of trinity.

When we tried to use this tool on our machine, segmentation fault happens.

I've analysed  the core dump with debuginfo, finding that the value of macro 'PF_MAX' on my machine is 46, however, this project defines the net_protocols[TRINITY_PF_MAX] with length of 45. And thus, when `i == 45`, and `rnd() % 4` hits 0,
```
static void do_random_sso(struct sockopt *so, struct socket_triplet *triplet)
{
	unsigned int i;
	const struct netproto *proto;

retry:
	switch (rnd() % 4) {       /* got 0 */
	case 0:	/* do a random protocol, even if it doesn't match this socket. */
		i = rnd() % PF_MAX;       /*got 45*/
		proto = net_protocols[i].proto;
		if (proto != NULL) {
			if (proto->setsockopt != NULL) { /* crashes here, for 'proto' points to invalid memory but passed null-pointer check. */
				proto->setsockopt(so, triplet);
				return;
			}
		}
		goto retry;
```
the main process crashes.

In `net.h`, it is said 
> glibc headers might be older than the kernel, so chances are we know about more protocols than glibc does. So we define our own PF_MAX.

I've checked versions of glibc and kernel, they appears to be
```
[root@localhost test]# rpm -q kernel
kernel-5.10.134-10.c8d67176d9.ali5000.alnx3.aarch64
[root@localhost test]# rpm -q glibc
glibc-2.36-6.alnx3.aarch64
```

This might happens rarely, but this commit helps to build the program more robust.
