### PR TITLE
fix memfd_create compile issue

### DIFF
--- a/configure
+++ b/configure
@@ -295,11 +295,12 @@ echo -n "[*] Checking if glibc provides memfd_create.. "
 rm -f "$TMP" || exit 1
 
 cat >"$TMP.c" << EOF
+#define _GNU_SOURCE
 #include <sys/mman.h>
 
 void main()
 {
-	memfd_create();
+	memfd_create("", 0);
 }
 EOF
 

--- a/fds/memfd.c
+++ b/fds/memfd.c
@@ -18,7 +18,6 @@
 
 #ifndef USE_MEMFD_CREATE
 
-#ifndef memfd_create
 static int memfd_create(__unused__ const char *uname, __unused__ unsigned int flag)
 {
 #ifdef SYS_memfd_create
@@ -27,7 +26,6 @@ static int memfd_create(__unused__ const char *uname, __unused__ unsigned int fl
 	return -ENOSYS;
 #endif
 }
-#endif
 #endif
 
 static void memfd_destructor(struct object *obj)


### PR DESCRIPTION
from man page, it requires _GNU_SOURCE, and it requires two parameters, so it would not be able to pass the configure check. It works with older gcc as old gcc allows conflict on 'static' keyword.

But it would hit copmile broken if not fixed on fedora 40. Because gcc version would check the declaration conflict on static function. In header it's not static, but in trinity, it's declared as static.

The 'ifndef memfd_create' don't work because memfd_create is not a macro, so remove it.

Before the fix:

[trinity.git]$ cat /etc/redhat-release
Fedora release 40 (Forty)
[trinity.git]$ ./configure | grep memfd_create
[*] Checking if glibc provides memfd_create.. [NO] [chuhu@dell-per7425-02 trinity.git]$ make -j8
  CC    arg-decoder.o
  CC    blockdevs.o
  CC    child.o
  CC    debug.o
  CC    devices.o
  CC    ftrace.o
  CC    generate-args.o
  CC    kcov.o
  CC    locks.o
  CC    log-files.o
  CC    log.o
  CC    main.o
  CC    objects.o
  CC    output.o
  CC    params.o
  CC    pathnames.o
  CC    pids.o
  CC    post-mortem.o
  CC    random-syscall.o
  CC    results.o
  CC    shm.o
  CC    signals.o
  CC    stats.o
  CC    syscall.o
  CC    sysv-shm.o
  CC    tables-biarch.o
  CC    tables-uniarch.o
  CC    tables.o
  CC    taint.o
  CC    trinity.o
  CC    uid.o
  CC    utils.o
  CC    fds/bpf.o
  CC    fds/drm.o
  CC    fds/epoll.o
  CC    fds/eventfd.o
  CC    fds/fanotify_init.o
  CC    fds/fds.o
  CC    fds/files.o
  CC    fds/inotify.o
  CC    fds/memfd.o
  CC    fds/perf.o
  CC    fds/pipes.o
  CC    fds/sockets.o
  CC    fds/testfiles.o
fds/memfd.c:22:12: error: static declaration of ‘memfd_create’ follows non-static declaration
   22 | static int memfd_create(__unused__ const char *uname, __unused__ unsigned int flag)
      |            ^~~~~~~~~~~~
In file included from /usr/include/bits/mman-linux.h:116,
                 from /usr/include/bits/mman.h:38,
                 from /usr/include/sys/mman.h:41,
                 from fds/memfd.c:8:
/usr/include/bits/mman-shared.h:55:5: note: previous declaration of ‘memfd_create’ with type ‘int(const char *, unsigned int)’
   55 | int memfd_create (const char *__name, unsigned int __flags) __THROW;
      |     ^~~~~~~~~~~~
make: *** [Makefile:113: fds/memfd.o] Error 1
make: *** Waiting for unfinished jobs....

After the fix:
[trinity]$ ./configure | grep memfd_create
[*] Checking if glibc provides memfd_create.. [YES]

[trinity]$ make -j8 | grep memfd_create
  CC    syscalls/memfd_create.o