### PR TITLE
Fixed "stack smashing" and "double freeing memory" issues

### DIFF
--- a/fds/memfd.c
+++ b/fds/memfd.c
@@ -31,6 +31,7 @@ static int memfd_create(__unused__ const char *uname, __unused__ unsigned int fl
 static void memfd_destructor(struct object *obj)
 {
 	free(obj->memfdobj.name);
+	obj->memfdobj.name = NULL;
 	close(obj->memfdobj.fd);
 }
 

--- a/fds/testfiles.c
+++ b/fds/testfiles.c
@@ -117,6 +117,8 @@ static int open_testfile_fds(void)
 	}
 
 	free(filename);
+	filename = NULL;
+
 	return TRUE;
 }
 

--- a/mm/maps.c
+++ b/mm/maps.c
@@ -62,7 +62,7 @@ void map_destructor(struct object *obj)
 void map_dump(struct object *obj, bool global)
 {
 	struct map *m;
-	char buf[11];
+	char buf[32];
 
 	m = &obj->map;
 

--- a/mm/maps.c
+++ b/mm/maps.c
@@ -57,6 +57,7 @@ void map_destructor(struct object *obj)
 	map = &obj->map;
 	munmap(map->ptr, map->size);
 	free(map->name);
+	map->name = NULL;
 }
 
 void map_dump(struct object *obj, bool global)
@@ -197,7 +198,9 @@ retry_mmap:
 		retries++;
 		if (retries == 100) {
 			free(obj->map.name);
+			obj->map.name = NULL;
 			free(obj);
+			obj = NULL;
 			return;
 		} else
 			goto retry_mmap;

--- a/pathnames.c
+++ b/pathnames.c
@@ -236,7 +236,6 @@ static const char ** list_to_index(struct namelist *namelist)
 		list_del(&nl->list);
 		free(nl);
 	}
-
 	free(names);
 	names = NULL;
 

--- a/utils.c
+++ b/utils.c
@@ -56,7 +56,7 @@ done:
 void sizeunit(unsigned long size, char *buf)
 {
 	/* non kilobyte aligned size? */
-	if (size & 1023) {
+	if (size < 1024) {
 		sprintf(buf, "%lu bytes", size);
 		return;
 	}


### PR DESCRIPTION
Fixed the following two issues:
    
1. "*** stack smashing detected ***: terminated" issue

This issue often occurs during opening large size file (descriptors) as the following.

Trinity 2023.01  Dave Jones <davej@codemonkey.org.uk>
shm:0x7fc8b52fa000-0x7fc8c1ef6d00 (4 pages)
[main] Done parsing arguments.
[main] Initial random seed: 2301061540
[main] 32-bit syscalls: 1 enabled, 443 disabled.  64-bit syscalls: 1 enabled, 450 disabled.
[main] Using pid_max = 4194304
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] Reserved/initialized 20 futexes.
[main] sysv_shm: id:162 size:24576 flags:7b0 ptr:(nil) global:1
[main] sysv_shm: id:163 size:8192 flags:17b0 ptr:(nil) global:1
[main] Generating file descriptors
[main] Added 49 filenames from /dev
[main] Added 41294 filenames from /proc
[main] Added 20508 filenames from /sys
*** stack smashing detected ***: terminated

The buffer overflow occurs (in mm/maps.c) when trinity tries to dump large size file.
E.g, on intel-x86-64 board, the size of "/sys/firmware/acpi/bgrt/image" is 109494 bytes.
The function of "sizeunit" put "109494 bytes" (12 chars) into the buf[11] causes the stack
smashing.


2. "free(): invalid next size (fast)" double freeing memory issue

This issue often occurs as below.

Trinity 2023.01  Dave Jones <davej@codemonkey.org.uk>
shm:0x7fa9747a4000-0x7fa9813a0d00 (4 pages)
[main] Done parsing arguments.
[main] Initial random seed: 2145030183
[main] 32-bit syscalls: 1 enabled, 443 disabled.  64-bit syscalls: 1 enabled, 450 disabled.
[main] Using pid_max = 4194304
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] futex: 0 owner:0 global:1
[main] Reserved/initialized 100 futexes.
[main] Generating file descriptors
[main] Added 84 filenames from /dev
[main] Added 94619 filenames from /proc
[main] Added 34537 filenames from /sys
free(): invalid next size (fast)

