### PR TITLE
net/proto-vsock.c: fix build on older distros

### DIFF
--- a/net/proto-vsock.c
+++ b/net/proto-vsock.c
@@ -1,5 +1,7 @@
 #include <sys/time.h>
 #include <stdlib.h>
+/* for struct sockaddr and sa_family_t, needed in vm_sockets.h, fixed by 22bbc1dcd0d6 */
+#include <sys/socket.h>
 #include <linux/vm_sockets.h>
 #include "net.h"
 #include "random.h"


### PR DESCRIPTION
Older distros do not include `sys/socket.h` -- added only by commit [22bbc1dcd0d6 ("vsock/uapi: fix linux/vm_sockets.h userspace compilation errors")](https://github.com/torvalds/linux//commit/22bbc1dcd0d6) upstream.

So the build fails with:
```
In file included from net/proto-vsock.c:3:
/usr/include/linux/vm_sockets.h:182:39: error: invalid application of ‘sizeof’ to incomplete type ‘struct sockaddr’
  182 |         unsigned char svm_zero[sizeof(struct sockaddr) -
      |                                       ^~~~~~
/usr/include/linux/vm_sockets.h:183:39: error: ‘sa_family_t’ undeclared here (not in a function)
  183 |                                sizeof(sa_family_t) -
      |                                       ^~~~~~~~~~~
```
Include the file before `vm_sockets.h`.