### PR TITLE
sunrpc: mark fam_sunrpc as used

### DIFF
--- a/net/netlink/genl/sunrpc.c
+++ b/net/netlink/genl/sunrpc.c
@@ -113,7 +113,7 @@ static const struct nla_attr_spec sunrpc_attrs[] = {
 	{ SUNRPC_A_IP_MAP_REQS_REQUESTS,	NLA_KIND_NESTED, 0 },
 };
 
-struct genl_family_grammar fam_sunrpc = {
+struct genl_family_grammar fam_sunrpc __attribute__((used)) = {
 	.name = SUNRPC_FAMILY_NAME,
 	.cmds = sunrpc_cmds,
 	.n_cmds = ARRAY_SIZE(sunrpc_cmds),


### PR DESCRIPTION
With LTO, I see:
```
  /usr/x86_64-suse-linux/bin/ld: /tmp/ccpD84iN.ltrans10.ltrans.o:(.data.rel.ro+0xc0): undefined reference to `fam_sunrpc'
```

Mark it as used as it is not declared in any header.